### PR TITLE
Now configure locale from _config file for compatibility with octopre…

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,6 +6,9 @@ permalink: /blog/:day/:month/:year/:title
 exclude: ["Gemfile", "Gemfile.lock", "README.md", "Rakefile"]
 highlighter: 'pygments'
 
+# set your locale
+lang: lv
+
 # Themes are encouraged to use these universal variables 
 # so be sure to set them if your theme uses them.
 #

--- a/_plugins/i18n_filter.rb
+++ b/_plugins/i18n_filter.rb
@@ -1,6 +1,6 @@
 require 'i18n'
 
-LOCALE = :lv # set your locale
+LOCALE = Jekyll.configuration({})['lang'] # set your locale from config var
 
 # Create folder "_locales" and put some locale file from https://github.com/svenfuchs/rails-i18n/tree/master/rails/locale
 module Jekyll


### PR DESCRIPTION
In my opinion, it seems like configuring locale in _config.yml file is the way to go. I added a new lang variable to make the filter compatible with octopress-multilingual gem
